### PR TITLE
style: misc xrpl-types improvements

### DIFF
--- a/ampd/src/handlers/xrpl_verify_msg.rs
+++ b/ampd/src/handlers/xrpl_verify_msg.rs
@@ -157,7 +157,7 @@ where
         let source_chain_str: String = source_chain.into();
         let message_ids = messages
             .iter()
-            .map(|message| message.tx_id().tx_hash_as_hex(true))
+            .map(|message| message.tx_id().tx_hash_as_hex())
             .collect::<Vec<_>>();
 
         let votes = info_span!(

--- a/contracts/voting-verifier/src/events.rs
+++ b/contracts/voting-verifier/src/events.rs
@@ -194,7 +194,7 @@ fn parse_message_id(
             let id = HexTxHash::from_str(message_id)
                 .map_err(|_| ContractError::InvalidMessageID(message_id.into()))?;
 
-            Ok((id.tx_hash_as_hex(true), 0))
+            Ok((id.tx_hash_as_hex(), 0))
         }
         MessageIdFormat::Bech32m { prefix, length } => {
             let bech32m_message_id = Bech32mFormat::from_str(prefix, *length as usize, message_id)

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -58,7 +58,7 @@ valuable = { version = "0.1.0", features = ["derive"] }
 assert_ok = { workspace = true }
 cw-multi-test = { workspace = true }
 goldie = { workspace = true }
-hex = { workspace = true, default-features = false }
+hex = { workspace = true }
 rand = { workspace = true }
 
 [lints]

--- a/packages/axelar-wasm-std/src/msg_id/tx_hash.rs
+++ b/packages/axelar-wasm-std/src/msg_id/tx_hash.rs
@@ -21,14 +21,17 @@ pub struct HexTxHash {
 }
 
 impl HexTxHash {
-    pub fn tx_hash_as_hex(&self, hex_prefix: bool) -> nonempty::String {
-        let hex = HexBinary::from(self.tx_hash).to_hex();
-        let result = if hex_prefix {
-            format!("0x{}", hex)
-        } else {
-            hex
-        };
-        result.try_into().expect("hex string cannot be empty")
+    pub fn tx_hash_as_hex(&self) -> nonempty::String {
+        format!("0x{}", self.tx_hash_as_hex_no_prefix())
+            .try_into()
+            .expect("failed to convert tx hash to non-empty string")
+    }
+
+    pub fn tx_hash_as_hex_no_prefix(&self) -> nonempty::String {
+        HexBinary::from(self.tx_hash)
+            .to_hex()
+            .try_into()
+            .expect("failed to convert tx hash to non-empty string")
     }
 
     pub fn new(tx_id: impl Into<[u8; 32]>) -> Self {
@@ -110,7 +113,7 @@ mod tests {
             let res = HexTxHash::from_str(&msg_id);
             let parsed = res.unwrap();
             assert_eq!(
-                parsed.tx_hash_as_hex(true),
+                parsed.tx_hash_as_hex(),
                 msg_id.clone().try_into().unwrap()
             );
             assert_eq!(parsed.to_string(), msg_id);

--- a/packages/xrpl-types/src/msg.rs
+++ b/packages/xrpl-types/src/msg.rs
@@ -171,9 +171,7 @@ impl XRPLUserMessage {
     pub fn cc_id(&self, source_chain: ChainNameRaw) -> CrossChainId {
         CrossChainId {
             source_chain,
-            message_id: format!("0x{}", HexBinary::from(self.tx_id.tx_hash).to_hex())
-                .try_into()
-                .expect("message_id conversion should never fail"),
+            message_id: self.tx_id.tx_hash_as_hex(),
         }
     }
 }

--- a/packages/xrpl-types/src/msg.rs
+++ b/packages/xrpl-types/src/msg.rs
@@ -93,7 +93,7 @@ pub struct XRPLProverMessage {
 impl From<XRPLUserMessage> for Vec<Attribute> {
     fn from(other: XRPLUserMessage) -> Self {
         let mut array = vec![
-            ("tx_id", other.tx_id.tx_hash_as_hex(false)).into(),
+            ("tx_id", other.tx_id.tx_hash_as_hex_no_prefix()).into(),
             ("source_address", other.source_address.to_string()).into(),
             ("destination_chain", other.destination_chain).into(),
             ("destination_address", other.destination_address.to_string()).into(),
@@ -111,10 +111,10 @@ impl From<XRPLUserMessage> for Vec<Attribute> {
 impl From<XRPLProverMessage> for Vec<Attribute> {
     fn from(other: XRPLProverMessage) -> Self {
         vec![
-            ("tx_id", other.tx_id.tx_hash_as_hex(false)).into(),
+            ("tx_id", other.tx_id.tx_hash_as_hex_no_prefix()).into(),
             (
                 "unsigned_tx_hash",
-                other.unsigned_tx_hash.tx_hash_as_hex(false),
+                other.unsigned_tx_hash.tx_hash_as_hex_no_prefix(),
             )
                 .into(),
         ]

--- a/packages/xrpl-types/src/types.rs
+++ b/packages/xrpl-types/src/types.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use axelar_wasm_std::msg_id::HexTxHash;
 use axelar_wasm_std::{nonempty, Participant, VerificationStatus};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, HexBinary, StdError, StdResult, Uint128, Uint256};
+use cosmwasm_std::{Addr, HexBinary, StdError, StdResult, Uint256};
 use cw_storage_plus::{Key, KeyDeserialize, PrimaryKey};
 use k256::ecdsa;
 use k256::schnorr::signature::SignatureEncoding;
@@ -128,18 +128,18 @@ pub struct XRPLToken {
 
 impl XRPLToken {
     pub fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(40);
+        let mut bytes = Vec::with_capacity(XRPL_ACCOUNT_ID_LENGTH + XRPL_CURRENCY_LENGTH);
         bytes.extend_from_slice(self.issuer.as_ref());
         bytes.extend_from_slice(self.currency.as_ref());
         bytes
     }
 
-    pub fn is_remote(&self, xrpl_multisig: XRPLAccountId) -> bool {
-        self.issuer == xrpl_multisig
+    pub fn is_local(&self, xrpl_multisig: XRPLAccountId) -> bool {
+        self.issuer != xrpl_multisig
     }
 
-    pub fn is_local(&self, xrpl_multisig: XRPLAccountId) -> bool {
-        !self.is_remote(xrpl_multisig)
+    pub fn is_remote(&self, xrpl_multisig: XRPLAccountId) -> bool {
+        !self.is_local(xrpl_multisig)
     }
 }
 
@@ -162,7 +162,7 @@ impl KeyDeserialize for XRPLToken {
     const KEY_ELEMS: u16 = 2;
 
     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
-        if value.len() != 40 {
+        if value.len() != XRPL_ACCOUNT_ID_LENGTH + XRPL_CURRENCY_LENGTH {
             return Err(StdError::generic_err("Invalid key length for XRPLToken"));
         }
 
@@ -247,12 +247,8 @@ impl PartialOrd for XRPLPaymentAmount {
             (
                 XRPLPaymentAmount::Issued(token_a, amount_a),
                 XRPLPaymentAmount::Issued(token_b, amount_b),
-            ) => {
-                if token_a == token_b {
-                    amount_a.partial_cmp(amount_b)
-                } else {
-                    None
-                }
+            ) if token_a == token_b => {
+                amount_a.partial_cmp(amount_b)
             }
             _ => None,
         }
@@ -326,13 +322,8 @@ impl Add for XRPLPaymentAmount {
             (
                 XRPLPaymentAmount::Issued(token_x, amount_x),
                 XRPLPaymentAmount::Issued(token_y, amount_y),
-            ) => {
-                if token_x != token_y {
-                    return Err(XRPLError::IncompatibleTokens);
-                }
-
-                let result_amount = amount_x.add(amount_y)?;
-                Ok(XRPLPaymentAmount::Issued(token_x, result_amount))
+            ) if token_x == token_y => {
+                Ok(XRPLPaymentAmount::Issued(token_x, amount_x.add(amount_y)?))
             }
             _ => Err(XRPLError::IncompatibleTokens),
         }
@@ -351,14 +342,9 @@ impl Sub for XRPLPaymentAmount {
             (
                 XRPLPaymentAmount::Issued(token_x, amount_x),
                 XRPLPaymentAmount::Issued(token_y, amount_y),
-            ) => {
-                if token_x != token_y {
-                    return Err(XRPLError::IncompatibleTokens);
-                }
-
-                let result_amount = amount_x.sub(amount_y)?;
-                Ok(XRPLPaymentAmount::Issued(token_x, result_amount))
-            }
+            ) if token_x == token_y => {
+                Ok(XRPLPaymentAmount::Issued(token_x, amount_x.sub(amount_y)?))
+            },
             _ => Err(XRPLError::IncompatibleTokens),
         }
     }

--- a/packages/xrpl-types/src/types.rs
+++ b/packages/xrpl-types/src/types.rs
@@ -11,7 +11,7 @@ use cw_storage_plus::{Key, KeyDeserialize, PrimaryKey};
 use k256::ecdsa;
 use k256::schnorr::signature::SignatureEncoding;
 use lazy_static::lazy_static;
-use multisig::key::{PublicKey, Signature};
+use multisig::key::PublicKey;
 use regex::Regex;
 use ripemd::Ripemd160;
 use router_api::{CrossChainId, FIELD_DELIMITER};
@@ -65,7 +65,7 @@ pub struct AxelarSigner {
 impl TryFrom<AxelarSigner> for Participant {
     type Error = XRPLError;
     fn try_from(signer: AxelarSigner) -> Result<Self, XRPLError> {
-        let weight = nonempty::Uint128::try_from(Uint128::from(u128::from(signer.weight)))
+        let weight = nonempty::Uint128::try_from(u128::from(signer.weight))
             .map_err(|_| XRPLError::InvalidSignerWeight(signer.weight))?;
 
         Ok(Self {
@@ -113,24 +113,6 @@ pub struct TxInfo {
     pub status: XRPLTxStatus,
     pub unsigned_contents: XRPLUnsignedTx,
     pub original_cc_id: Option<CrossChainId>,
-}
-
-#[cw_serde]
-#[derive(Ord, PartialOrd, Eq)]
-pub struct Operator {
-    pub address: HexBinary,
-    pub weight: Uint256,
-    pub signature: Option<Signature>,
-}
-
-impl Operator {
-    pub fn with_signature(self, sig: Signature) -> Operator {
-        Operator {
-            address: self.address,
-            weight: self.weight,
-            signature: Some(sig),
-        }
-    }
 }
 
 #[cw_serde]


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
