### PR TITLE
feat(xrpl-voting-verifier): use same Voted & PollEnded events as EVM

### DIFF
--- a/contracts/xrpl-voting-verifier/src/contract/execute.rs
+++ b/contracts/xrpl-voting-verifier/src/contract/execute.rs
@@ -179,6 +179,7 @@ pub fn vote(
         .add_event(Voted {
             poll_id,
             voter: info.sender,
+            votes,
         })
         .add_events(quorum_events.into_iter().flatten()))
 }
@@ -225,6 +226,7 @@ pub fn end_poll(deps: DepsMut, env: Env, poll_id: PollId) -> Result<Response, Co
         .add_event(PollEnded {
             poll_id: poll_result.poll_id,
             results: poll_result.results.0.clone(),
+            source_chain: config.source_chain,
         }))
 }
 

--- a/contracts/xrpl-voting-verifier/src/events.rs
+++ b/contracts/xrpl-voting-verifier/src/events.rs
@@ -106,6 +106,7 @@ impl From<PollStarted> for Event {
 pub struct Voted {
     pub poll_id: PollId,
     pub voter: Addr,
+    pub votes: Vec<Vote>,
 }
 
 impl From<Voted> for Event {
@@ -116,11 +117,16 @@ impl From<Voted> for Event {
                 serde_json::to_string(&other.poll_id).expect("failed to serialize poll_id"),
             )
             .add_attribute("voter", other.voter)
+            .add_attribute(
+                "votes",
+                serde_json::to_string(&other.votes).expect("failed to serialize votes"),
+            )
     }
 }
 
 pub struct PollEnded {
     pub poll_id: PollId,
+    pub source_chain: ChainName,
     pub results: Vec<Option<Vote>>,
 }
 
@@ -130,6 +136,11 @@ impl From<PollEnded> for Event {
             .add_attribute(
                 "poll_id",
                 serde_json::to_string(&other.poll_id).expect("failed to serialize poll_id"),
+            )
+            .add_attribute(
+                "source_chain",
+                serde_json::to_string(&other.source_chain)
+                    .expect("failed to serialize source_chain"),
             )
             .add_attribute(
                 "results",


### PR DESCRIPTION
## Description

Add missing attributes to `PollEnded` and `Voted` XRPLVotingVerifier events to match their EVM VotingVerifier's counterparts.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
