### PR TITLE
fix(xrpl-multisig-prover): next sequence number computation

### DIFF
--- a/contracts/xrpl-multisig-prover/src/state.rs
+++ b/contracts/xrpl-multisig-prover/src/state.rs
@@ -62,8 +62,6 @@ pub const CROSS_CHAIN_ID_TO_MULTISIG_SESSION: Map<&CrossChainId, MultisigSession
 pub const CONSUMED_TICKET_TO_UNSIGNED_TX_HASH: Map<&u32, Hash> =
     Map::new("consumed_ticket_to_unsigned_tx_hash");
 pub const UNSIGNED_TX_HASH_TO_TX_INFO: Map<&Hash, TxInfo> = Map::new("unsigned_tx_hash_to_tx_info");
-pub const LATEST_SEQUENTIAL_UNSIGNED_TX_HASH: Item<Hash> =
-    Item::new("latest_sequential_unsigned_tx_hash");
 pub const TRUST_LINE: Map<&XRPLToken, ()> = Map::new("trust_line");
 pub const TRUST_LINE_COUNT: Item<u64> = Item::new("trust_line_count");
 pub const SEQUENCE_NUMBER_MAX_OBJECT_COUNT: Map<&u32, u8> =


### PR DESCRIPTION
## Description

`next_sequence_number` checks `LATEST_SEQUENTIAL_UNSIGNED_TX_HASH`, which is redundant and can cause sequential transactions that will always be pending (because another TX with the same sequence already made it on-chain) to prevent the sequence number from ever progressing. This PR removes `LATEST_SEQUENTIAL_UNSIGNED_TX_HASH` and modifies `next_sequence_number` to always use `state::NEXT_SEQUENCE_NUMBER`.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
