### PR TITLE
feat(xrpl-gateway): query token instance from ITS Hub

### DIFF
--- a/contracts/xrpl-gateway/src/contract.rs
+++ b/contracts/xrpl-gateway/src/contract.rs
@@ -45,8 +45,6 @@ pub enum Error {
     ExecutionDisabled,
     #[error("unable to generate event index")]
     EventIndex,
-    #[error("forbidden chain {0}")]
-    ForbiddenChain(ChainNameRaw),
     #[error("invalid address")]
     InvalidAddress,
     #[error("invalid amount")]
@@ -131,12 +129,6 @@ pub enum Error {
     State,
     #[error(transparent)]
     Std(#[from] StdError),
-    #[error("token {token_id} deployed decimals mismatch: expected {expected}, actual {actual}")]
-    TokenDeployedDecimalsMismatch {
-        token_id: TokenId,
-        expected: u8,
-        actual: u8,
-    },
     #[error("failed to query token instance decimals for token {token_id} on chain {chain_name}")]
     TokenInstanceDecimals {
         chain_name: ChainNameRaw,

--- a/contracts/xrpl-gateway/src/contract.rs
+++ b/contracts/xrpl-gateway/src/contract.rs
@@ -144,11 +144,6 @@ pub enum Error {
     },
     #[error("token {0} not local")]
     TokenNotLocal(XRPLTokenOrXrp),
-    #[error("token {token_id} not registered for chain {chain_name}")]
-    TokenNotRegisteredForChain {
-        token_id: TokenId,
-        chain_name: ChainNameRaw,
-    },
     #[error("message {0:?} is not a valid incoming message")]
     UnsupportedIncomingMessage(XRPLMessage),
     #[error("failed to query xrpl token {0}")]
@@ -251,11 +246,6 @@ pub fn execute(
             token_id,
             xrpl_currency,
         ),
-        ExecuteMsg::RegisterTokenInstance {
-            token_id,
-            chain,
-            decimals,
-        } => execute::register_token_instance(deps.storage, &config, token_id, chain, decimals),
         ExecuteMsg::LinkToken {
             token_id,
             destination_chain,
@@ -300,7 +290,7 @@ pub fn execute(
         ),
         ExecuteMsg::RouteIncomingMessages(msgs) => {
             let verifier = client::ContractClient::new(deps.querier, &config.verifier).into();
-            execute::route_incoming_messages(deps.storage, &config, &verifier, msgs)
+            execute::route_incoming_messages(deps.storage, deps.querier, &config, &verifier, msgs)
         }
         ExecuteMsg::ConfirmAddGasMessages(msgs) => {
             let verifier = client::ContractClient::new(deps.querier, &config.verifier).into();
@@ -338,14 +328,28 @@ pub fn query(
         QueryMsg::TokenInstanceDecimals {
             chain_name,
             token_id,
-        } => query::token_instance_decimals(deps.storage, chain_name.clone(), token_id)
+        } => {
+            let config = state::load_config(deps.storage);
+            query::token_instance_decimals(
+                deps.querier,
+                config.its_hub,
+                chain_name.clone(),
+                token_id,
+            )
             .change_context(Error::TokenInstanceDecimals {
                 chain_name,
                 token_id,
-            }),
+            })
+        }
         QueryMsg::InterchainTransfer { message, payload } => {
             let config = state::load_config(deps.storage);
-            query::translate_to_interchain_transfer(deps.storage, &config, &message, payload)
+            query::translate_to_interchain_transfer(
+                deps.storage,
+                deps.querier,
+                &config,
+                &message,
+                payload,
+            )
         }
         QueryMsg::CallContract { message, payload } => {
             let config = state::load_config(deps.storage);

--- a/contracts/xrpl-gateway/src/contract/execute.rs
+++ b/contracts/xrpl-gateway/src/contract/execute.rs
@@ -6,8 +6,10 @@ use axelar_wasm_std::msg_id::HexTxHash;
 use axelar_wasm_std::{
     address, killswitch, nonempty, permission_control, FnExt, VerificationStatus,
 };
-use cosmwasm_std::{Addr, CosmosMsg, DepsMut, Event, HexBinary, Response, Storage, Uint256};
-use error_stack::{bail, ensure, report, Result, ResultExt};
+use cosmwasm_std::{
+    Addr, CosmosMsg, DepsMut, Event, HexBinary, QuerierWrapper, Response, Storage, Uint256,
+};
+use error_stack::{ensure, report, Result, ResultExt};
 use interchain_token_service::{self, TokenId};
 use itertools::Itertools;
 use router_api::client::Router;
@@ -19,10 +21,9 @@ use xrpl_types::msg::{
 };
 use xrpl_types::types::{
     scale_to_decimals, XRPLAccountId, XRPLCurrency, XRPLPaymentAmount, XRPLToken, XRPLTokenOrXrp,
-    XRPL_ISSUED_TOKEN_DECIMALS,
 };
 
-use crate::contract::Error;
+use crate::contract::{query, Error};
 use crate::events::XRPLGatewayEvent;
 use crate::msg::{CallContract, InterchainTransfer, LinkToken, MessageWithPayload, TokenMetadata};
 use crate::state::{self, Config};
@@ -64,6 +65,7 @@ fn verify(
 
 pub fn route_incoming_messages(
     storage: &mut dyn Storage,
+    querier: QuerierWrapper,
     config: &Config,
     verifier: &xrpl_voting_verifier::Client,
     msgs_with_payload: Vec<WithPayload<XRPLMessage>>,
@@ -89,6 +91,7 @@ pub fn route_incoming_messages(
                         event,
                     ) = translate_to_interchain_transfer(
                         storage,
+                        querier,
                         config,
                         &interchain_transfer_message,
                         msg.payload.clone(),
@@ -222,6 +225,7 @@ pub fn update_admin(deps: DepsMut, new_admin_address: String) -> Result<Response
 
 pub fn translate_to_interchain_transfer(
     storage: &dyn Storage,
+    querier: QuerierWrapper,
     config: &Config,
     interchain_transfer_message: &XRPLInterchainTransferMessage,
     payload: Option<nonempty::HexBinary>,
@@ -277,12 +281,17 @@ pub fn translate_to_interchain_transfer(
     let amount = match transfer_amount.clone() {
         XRPLPaymentAmount::Drops(drops) => Uint256::from(drops),
         XRPLPaymentAmount::Issued(_token, token_amount) => {
-            let destination_decimals =
-                state::load_token_instance_decimals(storage, destination_chain.clone(), token_id)
-                    .change_context(Error::TokenNotRegisteredForChain {
-                    token_id: token_id.to_owned(),
-                    chain_name: destination_chain.to_owned(),
-                })?;
+            let destination_decimals = query::token_instance(
+                querier,
+                config.its_hub.clone(),
+                destination_chain.clone(),
+                token_id,
+            )?
+            .decimals;
+
+            if destination_decimals > MAX_TOKEN_DECIMALS {
+                return Err(report!(Error::InvalidDecimals(destination_decimals)));
+            }
 
             scale_to_decimals(token_amount, destination_decimals).change_context(
                 Error::InvalidTransferAmount {
@@ -592,51 +601,6 @@ fn construct_its_hub_message(
     })
 }
 
-pub fn register_token_instance(
-    storage: &mut dyn Storage,
-    config: &Config,
-    token_id: TokenId,
-    chain: ChainNameRaw,
-    decimals: u8,
-) -> Result<Response, Error> {
-    if decimals > MAX_TOKEN_DECIMALS {
-        bail!(Error::InvalidDecimals(decimals));
-    }
-
-    if chain == config.chain_name {
-        bail!(Error::ForbiddenChain(chain));
-    }
-
-    match state::may_load_token_instance_decimals(storage, chain.clone(), token_id)
-        .change_context(Error::State)?
-    {
-        Some(expected_decimals) => {
-            ensure!(
-                decimals == expected_decimals,
-                Error::TokenDeployedDecimalsMismatch {
-                    token_id,
-                    expected: expected_decimals,
-                    actual: decimals,
-                }
-            );
-        }
-        None => {
-            state::save_token_instance_decimals(storage, chain.clone(), token_id, decimals)
-                .change_context(Error::State)?;
-
-            return Ok(
-                Response::default().add_event(XRPLGatewayEvent::TokenInstanceRegistered {
-                    token_id,
-                    chain,
-                    decimals,
-                }),
-            );
-        }
-    }
-
-    Ok(Response::default())
-}
-
 fn route_hub_message(
     config: &Config,
     nexus_client: &nexus::Client,
@@ -680,13 +644,6 @@ pub fn link_token(
     } else {
         let token =
             state::load_xrpl_token(storage, &token_id).change_context(Error::InvalidToken)?;
-        register_token_instance(
-            storage,
-            config,
-            token_id,
-            destination_chain.clone(),
-            XRPL_ISSUED_TOKEN_DECIMALS,
-        )?;
         XRPLTokenOrXrp::Issued(token)
     };
 
@@ -748,14 +705,6 @@ pub fn deploy_remote_token(
             token.decimals(),
         ),
     };
-
-    register_token_instance(
-        storage,
-        config,
-        token_id,
-        destination_chain.clone(),
-        destination_decimals,
-    )?;
 
     let TokenMetadata {
         name: token_name,

--- a/contracts/xrpl-gateway/src/contract/query.rs
+++ b/contracts/xrpl-gateway/src/contract/query.rs
@@ -1,7 +1,7 @@
 use axelar_wasm_std::error::extend_err;
 use axelar_wasm_std::nonempty;
-use cosmwasm_std::{to_json_binary, Binary, Storage};
-use error_stack::Result;
+use cosmwasm_std::{to_json_binary, Addr, Binary, QuerierWrapper, Storage};
+use error_stack::{Result, ResultExt};
 use interchain_token_service::TokenId;
 use router_api::{ChainNameRaw, CrossChainId, Message};
 use xrpl_types::msg::{XRPLCallContractMessage, XRPLInterchainTransferMessage};
@@ -50,23 +50,47 @@ pub fn linked_token_id(
     Ok(to_json_binary(&linked_token_id).map_err(state::Error::from)?)
 }
 
-pub fn token_instance_decimals(
-    storage: &dyn Storage,
+pub fn token_instance(
+    querier: QuerierWrapper,
+    its_hub: Addr,
     chain_name: ChainNameRaw,
     token_id: TokenId,
-) -> Result<Binary, state::Error> {
-    let decimals = state::load_token_instance_decimals(storage, chain_name, token_id)?;
-    Ok(to_json_binary(&decimals).map_err(state::Error::from)?)
+) -> Result<interchain_token_service::TokenInstance, Error> {
+    let query_msg = interchain_token_service::msg::QueryMsg::TokenInstance {
+        chain: chain_name.clone(),
+        token_id,
+    };
+
+    let token_instance: interchain_token_service::TokenInstance = querier
+        .query_wasm_smart(its_hub, &query_msg)
+        .change_context(Error::TokenInstanceDecimals {
+            token_id,
+            chain_name,
+        })?;
+
+    Ok(token_instance)
+}
+
+pub fn token_instance_decimals(
+    querier: QuerierWrapper,
+    its_hub: Addr,
+    chain_name: ChainNameRaw,
+    token_id: TokenId,
+) -> Result<Binary, Error> {
+    let decimals = token_instance(querier, its_hub, chain_name, token_id)?.decimals;
+
+    Ok(to_json_binary(&decimals).map_err(Error::from)?)
 }
 
 pub fn translate_to_interchain_transfer(
     storage: &dyn Storage,
+    querier: QuerierWrapper,
     config: &Config,
     message: &XRPLInterchainTransferMessage,
     payload: Option<nonempty::HexBinary>,
 ) -> Result<Binary, Error> {
     let (interchain_transfer, _) =
-        execute::translate_to_interchain_transfer(storage, config, message, payload)?;
+        execute::translate_to_interchain_transfer(storage, querier, config, message, payload)?;
     Ok(to_json_binary(&interchain_transfer).map_err(Error::from)?)
 }
 

--- a/contracts/xrpl-gateway/src/events.rs
+++ b/contracts/xrpl-gateway/src/events.rs
@@ -66,11 +66,6 @@ pub enum XRPLGatewayEvent {
         token_id: TokenId,
         token: XRPLToken,
     },
-    TokenInstanceRegistered {
-        token_id: TokenId,
-        chain: ChainNameRaw,
-        decimals: u8,
-    },
 }
 
 fn make_message_event<T: Into<Vec<Attribute>>>(event_name: &str, msg: T) -> Event {
@@ -186,14 +181,6 @@ impl From<XRPLGatewayEvent> for Event {
                     .add_attribute("token_id", token_id.to_string())
                     .add_attribute("token", token.to_string())
             }
-            XRPLGatewayEvent::TokenInstanceRegistered {
-                token_id,
-                chain,
-                decimals,
-            } => Event::new("token_instance_registered")
-                .add_attribute("token_id", token_id.to_string())
-                .add_attribute("chain", chain.to_string())
-                .add_attribute("decimals", decimals.to_string()),
         }
     }
 }

--- a/contracts/xrpl-gateway/src/msg.rs
+++ b/contracts/xrpl-gateway/src/msg.rs
@@ -77,14 +77,6 @@ pub enum ExecuteMsg {
         xrpl_currency: XRPLCurrency,
     },
 
-    /// Register a remote token that is deployed on another chain.
-    #[permission(Elevated)]
-    RegisterTokenInstance {
-        token_id: TokenId,
-        chain: ChainNameRaw,
-        decimals: u8,
-    },
-
     /// Deploy a token manager on some destination chain.
     #[permission(Elevated)]
     LinkToken {

--- a/contracts/xrpl-gateway/src/state.rs
+++ b/contracts/xrpl-gateway/src/state.rs
@@ -32,6 +32,12 @@ const XRPL_CURRENCY_TO_REMOTE_TOKEN_ID: Map<&XRPLCurrency, TokenId> =
 const XRPL_TOKEN_TO_LOCAL_TOKEN_ID: Map<&XRPLToken, TokenId> =
     Map::new("xrpl_token_to_local_token_id");
 const TOKEN_ID_TO_XRPL_TOKEN: Map<&TokenId, XRPLToken> = Map::new("token_id_to_xrpl_token");
+
+#[allow(dead_code)]
+#[deprecated(
+    since = "1.3.2",
+    note = "queried via interchain token service contract"
+)]
 const TOKEN_INSTACE_DECIMALS: Map<&(ChainNameRaw, TokenId), u8> =
     Map::new("token_instance_decimals");
 
@@ -99,37 +105,6 @@ pub fn count_gas(
     increment_gas(storage, token_id, gas)?;
     mark_gas_counted(storage, tx_id)?;
     Ok(())
-}
-
-pub fn may_load_token_instance_decimals(
-    storage: &dyn Storage,
-    chain_name: ChainNameRaw,
-    token_id: TokenId,
-) -> Result<Option<u8>, Error> {
-    TOKEN_INSTACE_DECIMALS
-        .may_load(storage, &(chain_name.clone(), token_id))
-        .change_context(Error::Storage)
-}
-
-pub fn load_token_instance_decimals(
-    storage: &dyn Storage,
-    chain_name: ChainNameRaw,
-    token_id: TokenId,
-) -> Result<u8, Error> {
-    may_load_token_instance_decimals(storage, chain_name.clone(), token_id)
-        .change_context(Error::Storage)?
-        .ok_or_else(|| report!(Error::TokenInstanceNotFound(chain_name, token_id)))
-}
-
-pub fn save_token_instance_decimals(
-    storage: &mut dyn Storage,
-    chain_name: ChainNameRaw,
-    token_id: TokenId,
-    decimals: u8,
-) -> Result<(), Error> {
-    TOKEN_INSTACE_DECIMALS
-        .save(storage, &(chain_name, token_id), &decimals)
-        .change_context(Error::Storage)
 }
 
 pub fn load_token_id(

--- a/contracts/xrpl-gateway/src/state.rs
+++ b/contracts/xrpl-gateway/src/state.rs
@@ -62,8 +62,6 @@ pub enum Error {
     TokenIdNotFound(XRPLCurrency),
     #[error("token ID for XRPL token {0} not found")]
     TokenIdNotFoundForToken(XRPLToken),
-    #[error("token instance for chain {0} and token {1} not found")]
-    TokenInstanceNotFound(ChainNameRaw, TokenId),
 }
 
 fn increment_gas(


### PR DESCRIPTION
## Description

So far, in order to support transfers of a given token between XRPL and a remote chain, you had to register the token instance (i.e., a chain-decimals pair) for every token, for every chain. Once this PR is merged, token instances will be queried from the ITS Hub, instead.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Steps to Test

## Expected Behaviour

## Other Notes
